### PR TITLE
Fix for link error on macOS

### DIFF
--- a/md5/src/x64.S
+++ b/md5/src/x64.S
@@ -23,8 +23,13 @@
 
 
 /* void md5_compress(uint32_t state[4], const uint8_t block[64]) */
+#ifdef __APPLE__
+.globl _md5_compress
+_md5_compress:
+#else
 .globl md5_compress
 md5_compress:
+#endif
     /* 
      * Storage usage:
      *   Bytes  Location  Description

--- a/md5/src/x86.S
+++ b/md5/src/x86.S
@@ -23,8 +23,13 @@
 
 
 /* void md5_compress(uint32_t state[4], const uint8_t block[64]) */
+#ifdef __APPLE__
+.globl _md5_compress
+_md5_compress:
+#else
 .globl md5_compress
 md5_compress:
+#endif
     /* 
      * Storage usage:
      *   Bytes  Location  Description

--- a/sha1/src/x64.S
+++ b/sha1/src/x64.S
@@ -23,8 +23,13 @@
 
 
 /* void sha1_compress(uint32_t state[5], const uint8_t block[64]) */
+#ifdef __APPLE__
+.globl _sha1_compress
+_sha1_compress:
+#else
 .globl sha1_compress
 sha1_compress:
+#endif
     /* 
      * Storage usage:
      *   Bytes  Location  Description

--- a/sha1/src/x86.S
+++ b/sha1/src/x86.S
@@ -23,8 +23,13 @@
 
 
 /* void sha1_compress(uint32_t state[5], const uint8_t block[64]) */
+#ifdef __APPLE__
+.globl _sha1_compress
+_sha1_compress:
+#else
 .globl sha1_compress
 sha1_compress:
+#endif
     /* 
      * Storage usage:
      *   Bytes  Location  Description

--- a/sha2/src/sha256_x64.S
+++ b/sha2/src/sha256_x64.S
@@ -23,8 +23,13 @@
 
 
 /* void sha256_compress(uint32_t state[8], const uint8_t block[64]) */
+#ifdef __APPLE__
+.globl _sha256_compress
+_sha256_compress:
+#else
 .globl sha256_compress
 sha256_compress:
+#endif
     /* 
      * Storage usage:
      *   Bytes  Location  Description

--- a/sha2/src/sha256_x86.S
+++ b/sha2/src/sha256_x86.S
@@ -23,8 +23,13 @@
 
 
 /* void sha256_compress(uint32_t state[8], const uint8_t block[64]) */
+#ifdef __APPLE__
+.globl _sha256_compress
+_sha256_compress:
+#else
 .globl sha256_compress
 sha256_compress:
+#endif
     /* 
      * Storage usage:
      *   Bytes  Location   Description

--- a/sha2/src/sha512_x64.S
+++ b/sha2/src/sha512_x64.S
@@ -23,8 +23,13 @@
 
 
 /* void sha512_compress(uint64_t state[8], const uint8_t block[128]) */
+#ifdef __APPLE__
+.globl _sha512_compress
+_sha512_compress:
+#else
 .globl sha512_compress
 sha512_compress:
+#endif
     /* 
      * Storage usage:
      *   Bytes  Location  Description

--- a/sha2/src/sha512_x86.S
+++ b/sha2/src/sha512_x86.S
@@ -23,8 +23,13 @@
 
 
 /* void sha512_compress(uint64_t state[8], const uint8_t block[128]) */
+#ifdef __APPLE__
+.globl _sha512_compress
+_sha512_compress:
+#else
 .globl sha512_compress
 sha512_compress:
+#endif
     /* 
      * Storage usage:
      *   Bytes  Location    Description

--- a/whirlpool/src/x64.S
+++ b/whirlpool/src/x64.S
@@ -24,8 +24,13 @@
 
 /* void whirlpool_compress(uint8_t state[64], const uint8_t block[64]) */
 /* state and block can be optionally aligned to 8 bytes for slightly better performance. */
+#ifdef __APPLE__
+.globl _whirlpool_compress
+_whirlpool_compress:
+#else
 .globl whirlpool_compress
 whirlpool_compress:
+#endif
     /*
      * Storage usage:
      *   Bytes  Location    Description

--- a/whirlpool/src/x86.S
+++ b/whirlpool/src/x86.S
@@ -24,8 +24,13 @@
 
 /* void whirlpool_compress(uint8_t state[64], const uint8_t block[64]) */
 /* state and block can be optionally aligned to 8 bytes for slightly better performance. */
+#ifdef __APPLE__
+.globl _whirlpool_compress
+_whirlpool_compress:
+#else
 .globl whirlpool_compress
 whirlpool_compress:
+#endif
     /* 
      * Storage usage:
      *   Bytes  Location    Description


### PR DESCRIPTION
Fixes https://github.com/RustCrypto/hashes/issues/54 by adding versions of the symbols named with leading underscores (conditionally on `__APPLE__`). Fix was suggested by https://github.com/alexcrichton/cc-rs/issues/317.