### PR TITLE
fix compilation issues with `cargo bench`

### DIFF
--- a/md5/benches/lib.rs
+++ b/md5/benches/lib.rs
@@ -8,7 +8,7 @@ use test::Bencher;
 #[bench]
 fn bench_compress(b: &mut Bencher) {
     let mut state = Default::default();
-    let data = Default::default();
+    let data = [0u8; 64];
 
     b.iter(|| {
         md5_asm::compress(&mut state, &data);

--- a/sha1/benches/lib.rs
+++ b/sha1/benches/lib.rs
@@ -8,7 +8,7 @@ use test::Bencher;
 #[bench]
 fn bench_compress(b: &mut Bencher) {
     let mut state = Default::default();
-    let data = Default::default();
+    let data = [0u8; 64];
 
     b.iter(|| {
         sha1_asm::compress(&mut state, &data);

--- a/sha2/benches/lib.rs
+++ b/sha2/benches/lib.rs
@@ -8,7 +8,7 @@ use test::Bencher;
 #[bench]
 fn bench_compress256(b: &mut Bencher) {
     let mut state = Default::default();
-    let data = Default::default();
+    let data = [0u8; 64];
 
     b.iter(|| {
         sha2_asm::compress256(&mut state, &data);
@@ -20,7 +20,7 @@ fn bench_compress256(b: &mut Bencher) {
 #[bench]
 fn bench_compress512(b: &mut Bencher) {
     let mut state = Default::default();
-    let data = Default::default();
+    let data = [0u8; 128];
 
     b.iter(|| {
         sha2_asm::compress512(&mut state, &data);

--- a/whirlpool/benches/lib.rs
+++ b/whirlpool/benches/lib.rs
@@ -7,8 +7,8 @@ use test::Bencher;
 
 #[bench]
 fn bench_compress(b: &mut Bencher) {
-    let mut state = Default::default();
-    let data = Default::default();
+    let mut state = [0u8; 64];
+    let data = [0u8; 64];
 
     b.iter(|| {
         whirlpool_asm::compress(&mut state, &data);


### PR DESCRIPTION
`Default::default()` isn't implemented for arrays larger than 32 elements.