### PR TITLE
speedup sha2 x86-64 assembly implementations

### DIFF
--- a/sha2/src/sha256_x64.S
+++ b/sha2/src/sha256_x64.S
@@ -92,14 +92,13 @@ sha256_compress:
     
     #define ROUNDTAIL(a, b, c, d, e, f, g, h, k)  \
         /* Part 0 */               \
-        movl  %e, %ecx;            \
-        movl  %e, %edx;            \
+        /* See Intel's "Fast SHA-256 Implementations" for the ROR transformation */ \
         movl  %e, %eax;            \
-        rorl  $11, %ecx;           \
-        rorl  $25, %edx;           \
+        rorl  $14, %eax;            \
+        xorl  %e, %eax;            \
+        rorl  $5, %eax;            \
+        xorl  %e, %eax;            \
         rorl  $6, %eax;            \
-        xorl  %edx, %ecx;          \
-        xorl  %ecx, %eax;          \
         addl  %ebx, %h;            \
         movl  %g, %ecx;            \
         xorl  %f, %ecx;            \
@@ -110,14 +109,13 @@ sha256_compress:
         /* Part 1 */               \
         addl  %h, %d;              \
         /* Part 2 */               \
-        movl  %a, %ecx;            \
-        movl  %a, %edx;            \
+        /* See Intel's "Fast SHA-256 Implementations" for the ROR transformation */ \
         movl  %a, %eax;            \
-        rorl  $13, %ecx;           \
-        rorl  $22, %edx;           \
+        rorl  $9, %eax;            \
+        xorl  %a, %eax;            \
+        rorl  $11, %eax;           \
+        xorl  %a, %eax;            \
         rorl  $2, %eax;            \
-        xorl  %edx, %ecx;          \
-        xorl  %ecx, %eax;          \
         movl  %c, %ecx;            \
         addl  %eax, %h;            \
         movl  %c, %eax;            \

--- a/sha2/src/sha512_x64.S
+++ b/sha2/src/sha512_x64.S
@@ -92,14 +92,13 @@ sha512_compress:
     
     #define ROUNDTAIL(a, b, c, d, e, f, g, h, k)  \
         /* Part 0 */       \
-        movq  %e, %rcx;    \
-        movq  %e, %rdx;    \
+        /* ROR transformation inspired by Intel's SHA-256 implementation */ \
         movq  %e, %rax;    \
-        rorq  $18, %rcx;   \
-        rorq  $41, %rdx;   \
+        rorq  $23, %rax;    \
+        xorq  %e, %rax;    \
+        rorq  $4, %rax;    \
+        xorq  %e, %rax;    \
         rorq  $14, %rax;   \
-        xorq  %rdx, %rcx;  \
-        xorq  %rcx, %rax;  \
         addq  %rbx, %h;    \
         movq  %g, %rcx;    \
         xorq  %f, %rcx;    \
@@ -112,14 +111,13 @@ sha512_compress:
         /* Part 1 */       \
         addq  %h, %d;      \
         /* Part 2 */       \
-        movq  %a, %rcx;    \
-        movq  %a, %rdx;    \
+        /* ROR transformation inspired by Intel's SHA-256 implementation */ \
         movq  %a, %rax;    \
-        rorq  $39, %rcx;   \
-        rorq  $34, %rdx;   \
+        rorq  $5, %rax;    \
+        xorq  %a, %rax;    \
+        rorq  $6, %rax;    \
+        xorq  %a, %rax;    \
         rorq  $28, %rax;   \
-        xorq  %rdx, %rcx;  \
-        xorq  %rcx, %rax;  \
         movq  %c, %rcx;    \
         addq  %rax, %h;    \
         movq  %c, %rax;    \


### PR DESCRIPTION
The rearrangement of the sigma functions was suggested in Intel's "Fast
SHA-256 Implementations" whitepaper, and the constants for the SHA-256
implementation are taken from there.  The constants for the SHA-512
implementation were derived via exhaustive search + random testing.

Performance improves on SHA-256 by ~10% locally, and on SHA-512 by ~15-20%.