### PR TITLE
Make a release of both sha1-asm and sha2-asm

### DIFF
--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1-asm"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["RustCrypto Developers"]
 license = "MIT"
 description = "Assembly implementation of SHA-1 compression function"

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2-asm"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["RustCrypto Developers"]
 license = "MIT"
 description = "Assembly implementation of SHA-2 compression functions"
@@ -8,8 +8,6 @@ documentation = "https://docs.rs/sha2-asm"
 repository = "https://github.com/RustCrypto/asm-hashes"
 keywords = ["crypto", "sha2", "asm"]
 categories = ["cryptography", "no-std"]
-
-[dependencies]
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
This only adds AArch64 support, everything else should be identical, so we can make a patch release instead of a minor one.

https://github.com/RustCrypto/hashes/pull/97 depends on that release.