### PR TITLE
Use CARGO_CFG_TARGET_ARCH in build.rs scripts

### DIFF
--- a/md5/build.rs
+++ b/md5/build.rs
@@ -1,9 +1,11 @@
 extern crate cc;
 
 fn main() {
-    let asm_path = if cfg!(target_arch = "x86") {
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    let asm_path = if target_arch == "x86" {
         "src/x86.S"
-    } else if cfg!(target_arch = "x86_64") {
+    } else if target_arch == "x86_64" {
         "src/x64.S"
     } else {
         panic!("Unsupported target architecture");

--- a/sha1/build.rs
+++ b/sha1/build.rs
@@ -1,17 +1,19 @@
 extern crate cc;
 
 fn main() {
-    let asm_path = if cfg!(target_arch = "x86") {
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    let asm_path = if target_arch == "x86" {
         "src/x86.S"
-    } else if cfg!(target_arch = "x86_64") {
+    } else if target_arch == "x86_64" {
         "src/x64.S"
-    } else if cfg!(target_arch = "aarch64") {
+    } else if target_arch == "aarch64" {
         "src/aarch64.S"
     } else {
         panic!("Unsupported target architecture");
     };
     let mut build = cc::Build::new();
-    if cfg!(target_arch = "aarch64") {
+    if target_arch == "aarch64" {
         build.flag("-march=armv8-a+crypto");
     }
     build.flag("-c")

--- a/sha2/build.rs
+++ b/sha2/build.rs
@@ -1,18 +1,20 @@
 extern crate cc;
 
 fn main() {
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
     let mut build256 = cc::Build::new();
-    let (sha256_path, sha512_path) = if cfg!(target_arch = "x86") {
+    let (sha256_path, sha512_path) = if target_arch == "x86" {
         ("src/sha256_x86.S", "src/sha512_x86.S")
-    } else if cfg!(target_arch = "x86_64") {
+    } else if target_arch == "x86_64" {
         ("src/sha256_x64.S", "src/sha512_x64.S")
-    } else if cfg!(target_arch = "aarch64") {
+    } else if target_arch == "aarch64" {
         build256.flag("-march=armv8-a+crypto");
         ("src/sha256_aarch64.S", "")
     } else {
         panic!("Unsupported target architecture");
     };
-    if !cfg!(target_arch = "aarch64") {
+    if target_arch != "aarch64" {
         cc::Build::new()
                   .flag("-c")
                   .file(sha512_path)

--- a/whirlpool/build.rs
+++ b/whirlpool/build.rs
@@ -1,9 +1,11 @@
 extern crate cc;
 
 fn main() {
-    let asm_path = if cfg!(target_arch = "x86") {
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    let asm_path = if target_arch == "x86" {
         "src/x86.S"
-    } else if cfg!(target_arch = "x86_64") {
+    } else if target_arch == "x86_64" {
         "src/x64.S"
     } else {
         panic!("Unsupported target architecture");


### PR DESCRIPTION
Using cargos target flags in build.rs doesn't work for cross compilation scenarios because the build.rs is compiled for the host machine and not the target.
Update the target check to use `CARGO_CFG_TARGET_ARCH` as suggested here: https://github.com/rust-lang/cargo/issues/4302

Fixes #15 