### PR TITLE
CI: add note about `marcopolo/cargo`

### DIFF
--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -47,6 +47,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
           override: true
+      # NOTE: using `marcopolo/cargo` fork to support the `working-directory` attribute
+      # See: https://github.com/actions-rs/cargo/pull/59
       - uses: marcopolo/cargo@master
         with:
           command: test

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -63,6 +63,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+      # NOTE: using `marcopolo/cargo` fork to support the `working-directory` attribute
+      # See: https://github.com/actions-rs/cargo/pull/59
       - uses: marcopolo/cargo@master
         with:
           command: test

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -67,6 +67,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+      # NOTE: using `marcopolo/cargo` fork to support the `working-directory` attribute
+      # See: https://github.com/actions-rs/cargo/pull/59
       - uses: marcopolo/cargo@master
         with:
           command: test


### PR DESCRIPTION
The GitHub Actions recipe is using a fork of `actions-rs/cargo` which includes this PR to support a `working-directory` attribute:

https://github.com/actions-rs/cargo/pull/59

Ideally `actions-rs/cargo` will eventually merge this PR.