### PR TITLE
Process block slices instead of separate blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,28 +9,28 @@ checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 
 [[package]]
 name = "md5-asm"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "sha1-asm"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "sha2-asm"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "whirlpool-asm"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "cc",
 ]

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md5-asm"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "MIT"
 description = "Assembly implementation of MD5 compression function"
@@ -12,6 +12,3 @@ edition = "2018"
 
 [build-dependencies]
 cc = "1.0"
-
-[badges]
-travis-ci = { repository = "RustCrypto/asm-hashes" }

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -21,6 +21,8 @@ extern "C" {
 #[inline]
 pub fn compress(state: &mut [u32; 4], blocks: &[[u8; 64]]) {
     for block in blocks {
-        unsafe { md5_compress(state, block); }
+        unsafe {
+            md5_compress(state, block);
+        }
     }
 }

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -1,12 +1,12 @@
-//! Assembly implementation of [MD5][1] compression function.
+//! Assembly implementation of the [MD5] compression function.
 //!
-//! For full MD5 hash function with this implementation of compression function
-//! use [md-5](https://crates.io/crates/md-5) crate with
-//! the enabled "asm" feature.
+//! This crate is not intended for direct use, most users should
+//! prefer the [`md5`] crate with enabled `asm` feature instead.
 //!
 //! Only x86 and x86-64 architectures are currently supported.
 //!
-//! [1]: https://en.wikipedia.org/wiki/MD5
+//! [MD5]: https://en.wikipedia.org/wiki/MD5
+//! [`md5`]: https://crates.io/crates/md5
 
 #![no_std]
 #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
@@ -19,8 +19,8 @@ extern "C" {
 
 /// Safe wrapper around assembly implementation of MD5 compression function
 #[inline]
-pub fn compress(state: &mut [u32; 4], block: &[u8; 64]) {
-    unsafe {
-        md5_compress(state, block);
+pub fn compress(state: &mut [u32; 4], blocks: &[[u8; 64]]) {
+    for block in blocks {
+        unsafe { md5_compress(state, block); }
     }
 }

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1-asm"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 license = "MIT"
 description = "Assembly implementation of SHA-1 compression function"
@@ -12,6 +12,3 @@ edition = "2018"
 
 [build-dependencies]
 cc = "1.0"
-
-[badges]
-travis-ci = { repository = "RustCrypto/asm-hashes" }

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -21,6 +21,8 @@ extern "C" {
 #[inline]
 pub fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
     for block in blocks {
-        unsafe { sha1_compress(state, block); }
+        unsafe {
+            sha1_compress(state, block);
+        }
     }
 }

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -1,12 +1,12 @@
-//! Assembly implementation of [SHA-1][1] compression function.
+//! Assembly implementation of the [SHA-1] compression function.
 //!
-//! For full SHA-1 hash function with this implementation of compression function
-//! use [sha-1](https://crates.io/crates/sha-1) crate with
-//! the enabled "asm" feature.
+//! This crate is not intended for direct use, most users should
+//! prefer the [`sha-1`] crate with enabled `asm` feature instead.
 //!
-//! Only x86 and x86-64 architectures are currently supported.
+//! Only x86, x86-64, and AArch64 architectures are currently supported.
 //!
-//! [1]: https://en.wikipedia.org/wiki/SHA-1
+//! [SHA-1]: https://en.wikipedia.org/wiki/SHA-1
+//! [`sha-1`]: https://crates.io/crates/sha-1
 
 #![no_std]
 #[cfg(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))]
@@ -19,8 +19,8 @@ extern "C" {
 
 /// Safe wrapper around assembly implementation of SHA-1 compression function
 #[inline]
-pub fn compress(state: &mut [u32; 5], block: &[u8; 64]) {
-    unsafe {
-        sha1_compress(state, block);
+pub fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+    for block in blocks {
+        unsafe { sha1_compress(state, block); }
     }
 }

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2-asm"
-version = "0.5.5"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "MIT"
 description = "Assembly implementation of SHA-2 compression functions"

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -1,12 +1,13 @@
-//! Assembly implementation of [SHA-2][1] compression functions.
+//! Assembly implementation of the [SHA-2] compression functions.
 //!
-//! For full SHA-2 hash functions with this implementation of compression
-//! functions use [sha-2](https://crates.io/crates/sha-2) crate with
-//! the enabled "asm" feature.
+//! This crate is not intended for direct use, most users should
+//! prefer the [`sha2`] crate with enabled `asm` feature instead.
 //!
-//! Only x86 and x86-64 architectures are currently supported.
+//! Only x86, x86-64, and (partially) AArch64 architectures are
+//! currently supported.
 //!
-//! [1]: https://en.wikipedia.org/wiki/SHA-2
+//! [SHA-2]: https://en.wikipedia.org/wiki/SHA-2
+//! [`sha2`]: https://crates.io/crates/sha2
 
 #![no_std]
 #[cfg(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))]
@@ -19,8 +20,10 @@ extern "C" {
 
 /// Safe wrapper around assembly implementation of SHA256 compression function
 #[inline]
-pub fn compress256(state: &mut [u32; 8], block: &[u8; 64]) {
-    unsafe { sha256_compress(state, block) }
+pub fn compress256(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+    for block in blocks {
+        unsafe { sha256_compress(state, block) }
+    }
 }
 
 #[cfg(not(target_arch = "aarch64"))]
@@ -30,8 +33,12 @@ extern "C" {
 }
 
 /// Safe wrapper around assembly implementation of SHA512 compression function
+///
+/// This function is available only on x86 and x86-64 targets.
 #[cfg(not(target_arch = "aarch64"))]
 #[inline]
-pub fn compress512(state: &mut [u64; 8], block: &[u8; 128]) {
-    unsafe { sha512_compress(state, block) }
+pub fn compress512(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+    for block in blocks {
+        unsafe { sha512_compress(state, block) }
+    }
 }

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool-asm"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["RustCrypto Developers"]
 license = "MIT"
 description = "Assembly implementation of Whirlpool compression function"
@@ -12,6 +12,3 @@ edition = "2018"
 
 [build-dependencies]
 cc = "1.0"
-
-[badges]
-travis-ci = { repository = "RustCrypto/asm-hashes" }

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -1,12 +1,12 @@
-//! Assembly implementation of [Whirlpool][1] compression function.
+//! Assembly implementation of the [Whirlpool] compression function.
 //!
-//! For full Whirlpool hash function with this implementation of compression
-//! function use [whirlpool](https://crates.io/crates/whirlpool) crate with
-//! the enabled "asm" feature.
+//! This crate is not intended for direct use, most users should
+//! prefer the [`whirlpool`] crate with enabled `asm` feature instead.
 //!
 //! Only x86 and x86-64 architectures are currently supported.
 //!
-//! [1]: https://en.wikipedia.org/wiki/Whirlpool_(cryptography)
+//! [Whirlpool]: https://en.wikipedia.org/wiki/Whirlpool_(cryptography)
+//! [`whirlpool`]: https://crates.io/crates/whirlpool
 
 #![no_std]
 #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
@@ -14,11 +14,13 @@ compile_error!("crate can only be used on x86 and x86-64 architectures");
 
 #[link(name = "whirlpool", kind = "static")]
 extern "C" {
-    fn whirlpool_compress(state: &mut [u8; 64], block: &[u8; 64]);
+    fn whirlpool_compress(state: &mut [u64; 8], block: &[u8; 64]);
 }
 
-/// Safe wrapper around assembly implementation of Whirlpool compression function
+/// Safe wrapper around assembly implementation of the Whirlpool compression function
 #[inline]
-pub fn compress(state: &mut [u8; 64], block: &[u8; 64]) {
-    unsafe { whirlpool_compress(state, block) }
+pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 64]]) {
+    for block in blocks {
+        unsafe { whirlpool_compress(state, block) }
+    }
 }


### PR DESCRIPTION
Preliminary work on #26.

This PR simply loops over blocks on Rust side, for optimal performance the assembly code has to be modified.