### PR TITLE
sha2-asm v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "sha2-asm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cc",
 ]

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.6.1 (2021-05-05)
+### Added
+- `aarch64` implementation of SHA-256 for the M1 chip ([#35])
+
+[#35]: https://github.com/RustCrypto/asm-hashes/pull/35
+
+## 0.6.0 (2021-02-09)
+
+## 0.5.5 (2021-01-25)
+
+## 0.5.4 (2020-06-11)
+
+## 0.5.3 (2020-01-05)
+
+## 0.5.2 (2019-04-15)
+
+## 0.5.1 (2018-05-15)
+
+## 0.5.0 (2018-04-27)
+
+## 0.4.0 (2018-03-19)
+
+## 0.3.0 (2017-06-27)
+
+## 0.2.1 (2017-05-09)
+
+## 0.2.0 (2017-05-08)
+
+## 0.1.0 (2017-05-07)

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2-asm"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["RustCrypto Developers"]
 license = "MIT"
 description = "Assembly implementation of SHA-2 compression functions"


### PR DESCRIPTION
### Added
- `aarch64` implementation of SHA-256 for the M1 chip ([#35])

[#35]: https://github.com/RustCrypto/asm-hashes/pull/35