### PR TITLE
sha2-asm v0.6.2

### DIFF
--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.2 (2021-07-16)
+### Fixed
+- Builds on iOS targets ([#38])
+
+[#38]: https://github.com/RustCrypto/asm-hashes/pull/38
+
 ## 0.6.1 (2021-05-05)
 ### Added
 - `aarch64` implementation of SHA-256 for the M1 chip ([#35])

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2-asm"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["RustCrypto Developers"]
 license = "MIT"
 description = "Assembly implementation of SHA-2 compression functions"


### PR DESCRIPTION
### Fixed
- Builds on iOS targets ([#38])

[#38]: https://github.com/RustCrypto/asm-hashes/pull/38