### PR TITLE
.github: disable `cross` builds on old rustcs

### DIFF
--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -96,8 +96,8 @@ jobs:
       matrix:
         include:
           # ARM64
-          - target: aarch64-unknown-linux-gnu
-            rust: 1.43.0 # MSRV
+          #- target: aarch64-unknown-linux-gnu
+          #  rust: 1.43.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -96,8 +96,8 @@ jobs:
       matrix:
         include:
           # ARM64
-          - target: aarch64-unknown-linux-gnu
-            rust: 1.43.0 # MSRV
+          #- target: aarch64-unknown-linux-gnu
+          #  rust: 1.43.0 # MSRV
           - target: aarch64-unknown-linux-gnu
             rust: stable
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "sha2-asm"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Cross is failing to install on Rust 1.43.0 (current MSRV) anymore:

https://github.com/RustCrypto/asm-hashes/pull/41/checks?check_run_id=3513675295

This comments out the `cross` tests on these platforms for now.