### PR TITLE
Add Dependabot configuration file to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Add Dependabot configuration to automatically open PRs for outdated actions and crates.

Inspired by https://github.com/RustCrypto/hashes/pull/410#issuecomment-1252658128.