### PR TITLE
Fix deprecated use of `cc::Build::compile` in `build.rs`

### DIFF
--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.43.0 # MSRV
+          - 1.54.0 # MSRV
           - stable
 
     runs-on: macos-latest

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.43.0 # MSRV
+          - 1.54.0 # MSRV
           - stable
 
     runs-on: macos-latest

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.43.0 # MSRV
+          - 1.54.0 # MSRV
           - stable
 
     runs-on: macos-latest

--- a/.github/workflows/whirlpool.yml
+++ b/.github/workflows/whirlpool.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.43.0 # MSRV
+          - 1.54.0 # MSRV
           - stable
 
     runs-on: macos-latest

--- a/md5/build.rs
+++ b/md5/build.rs
@@ -8,8 +8,5 @@ fn main() {
     } else {
         panic!("Unsupported target architecture");
     };
-    cc::Build::new()
-        .flag("-c")
-        .file(asm_path)
-        .compile("libmd5.a");
+    cc::Build::new().flag("-c").file(asm_path).compile("md5");
 }

--- a/sha1/build.rs
+++ b/sha1/build.rs
@@ -17,5 +17,5 @@ fn main() {
     if target_arch == "aarch64" {
         build.flag("-march=armv8-a+crypto");
     }
-    build.flag("-c").file(asm_path).compile("libsha1.a");
+    build.flag("-c").file(asm_path).compile("sha1");
 }

--- a/sha2/build.rs
+++ b/sha2/build.rs
@@ -1,6 +1,6 @@
-fn main() {
-    use std::env;
+use std::env;
 
+fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap_or_default();
 
@@ -25,5 +25,5 @@ fn main() {
             .file(sha512_path)
             .compile("libsha512.a");
     }
-    build256.flag("-c").file(sha256_path).compile("libsha256.a");
+    build256.flag("-c").file(sha256_path).compile("sha256");
 }

--- a/whirlpool/build.rs
+++ b/whirlpool/build.rs
@@ -11,5 +11,5 @@ fn main() {
     cc::Build::new()
         .flag("-c")
         .file(asm_path)
-        .compile("libwhirlpool.a");
+        .compile("whirlpool");
 }


### PR DESCRIPTION
and fixed the path to assemblies on windows.

I encountered link time failure when compiling on Windows locally and on CI:

```
  error occurred: Command "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.36.32532\\bin\\HostX86\\arm64\\lib.exe" "-out:C:\\Users\\nobodyxu\\cargo-binstall\\target\\aarch64-pc-windows-msvc\\debug\\build\\sha1-asm-600eae65c368c0c1\\out\\libsha1.a" "-nologo" "C:\\Users\\nobodyxu\\cargo-binstall\\target\\aarch64-pc-windows-msvc\\debug\\build\\sha1-asm-600eae65c368c0c1\\out\\src/aarch64.o" with args "lib.exe" did not execute successfully (status code exit code: 1181).
```

I think this might have something to do with use of deprecated feature of [`cc::Build::compile`](https://docs.rs/cc/latest/cc/struct.Build.html#method.compile):

> For backwards compatibility, if output starts with “lib” and ends with “.a”, a second “lib” prefix and “.a” suffix do not get added on, but this usage is deprecated; please omit lib and .a in the argument that you pass.

It should pass just a name instead and msvc would deal with that:

> The output string argument determines the file name for the compiled library. The Rust compiler will create an assembly named “lib”+output+“.a”. MSVC will create a file named output+“.lib”.

~~Also, the `build.rs` are using `/` on windows, this might also be the cause of failure.~~

Related issue https://github.com/Byron/gitoxide/issues/917#

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>