### PR TITLE
prefix x86 asm symbols with `_` on Windows like on Apple

### DIFF
--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.43.0 # MSRV
+          - 1.54.0 # MSRV
           - stable
 
     runs-on: macos-latest
@@ -74,8 +74,13 @@ jobs:
         include:
           # 64-bit Windows (GNU)
           - target: x86_64-pc-windows-gnu
-            toolchain: 1.43.0 # MSRV
+            toolchain: 1.48.0 # MSRV
           - target: x86_64-pc-windows-gnu
+            toolchain: stable
+          # 32-bit Windows (GNU)
+          - target: i686-pc-windows-gnu
+            toolchain: 1.48.0 # MSRV
+          - target: i686-pc-windows-gnu
             toolchain: stable
 
     runs-on: windows-latest
@@ -86,4 +91,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target }}
       - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW${{ startsWith(matrix.target, 'i686-') && '32' || '64' }}
+          pacboy: cc:p
+          path-type: inherit
       - run: cargo test --target ${{ matrix.target }} --release
+        shell: msys2 {0}

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.43.0 # MSRV
+          - 1.54.0 # MSRV
           - stable
 
     runs-on: macos-latest
@@ -72,8 +72,13 @@ jobs:
         include:
           # 64-bit Windows (GNU)
           - target: x86_64-pc-windows-gnu
-            toolchain: 1.43.0 # MSRV
+            toolchain: 1.48.0 # MSRV
           - target: x86_64-pc-windows-gnu
+            toolchain: stable
+          # 32-bit Windows (GNU)
+          - target: i686-pc-windows-gnu
+            toolchain: 1.48.0 # MSRV
+          - target: i686-pc-windows-gnu
             toolchain: stable
 
     runs-on: windows-latest
@@ -84,7 +89,12 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target }}
       - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW${{ startsWith(matrix.target, 'i686-') && '32' || '64' }}
+          pacboy: cc:p
+          path-type: inherit
       - run: cargo test --target ${{ matrix.target }} --release
+        shell: msys2 {0}
 
   # Cross-compiled tests
   cross:

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.43.0 # MSRV
+          - 1.54.0 # MSRV
           - stable
 
     runs-on: macos-latest
@@ -72,8 +72,13 @@ jobs:
         include:
           # 64-bit Windows (GNU)
           - target: x86_64-pc-windows-gnu
-            toolchain: 1.43.0 # MSRV
+            toolchain: 1.48.0 # MSRV
           - target: x86_64-pc-windows-gnu
+            toolchain: stable
+          # 32-bit Windows (GNU)
+          - target: i686-pc-windows-gnu
+            toolchain: 1.48.0 # MSRV
+          - target: i686-pc-windows-gnu
             toolchain: stable
 
     runs-on: windows-latest
@@ -84,7 +89,12 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target }}
       - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW${{ startsWith(matrix.target, 'i686-') && '32' || '64' }}
+          pacboy: cc:p
+          path-type: inherit
       - run: cargo test --target ${{ matrix.target }} --release
+        shell: msys2 {0}
 
   # Cross-compiled tests
   cross:

--- a/.github/workflows/whirlpool.yml
+++ b/.github/workflows/whirlpool.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.43.0 # MSRV
+          - 1.54.0 # MSRV
           - stable
 
     runs-on: macos-latest
@@ -74,8 +74,13 @@ jobs:
         include:
           # 64-bit Windows (GNU)
           - target: x86_64-pc-windows-gnu
-            toolchain: 1.43.0 # MSRV
+            toolchain: 1.48.0 # MSRV
           - target: x86_64-pc-windows-gnu
+            toolchain: stable
+          # 32-bit Windows (GNU)
+          - target: i686-pc-windows-gnu
+            toolchain: 1.48.0 # MSRV
+          - target: i686-pc-windows-gnu
             toolchain: stable
 
     runs-on: windows-latest
@@ -86,4 +91,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target }}
       - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW${{ startsWith(matrix.target, 'i686-') && '32' || '64' }}
+          pacboy: cc:p
+          path-type: inherit
       - run: cargo test --target ${{ matrix.target }} --release
+        shell: msys2 {0}

--- a/md5/src/x86.S
+++ b/md5/src/x86.S
@@ -23,7 +23,7 @@
 
 
 /* void md5_compress(uint32_t state[4], const uint8_t block[64]) */
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(_WIN32)
 .globl _md5_compress
 _md5_compress:
 #else

--- a/sha1/src/x86.S
+++ b/sha1/src/x86.S
@@ -23,7 +23,7 @@
 
 
 /* void sha1_compress(uint32_t state[5], const uint8_t block[64]) */
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(_WIN32)
 .globl _sha1_compress
 _sha1_compress:
 #else

--- a/sha2/src/sha256_x86.S
+++ b/sha2/src/sha256_x86.S
@@ -23,7 +23,7 @@
 
 
 /* void sha256_compress(uint32_t state[8], const uint8_t block[64]) */
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(_WIN32)
 .globl _sha256_compress
 _sha256_compress:
 #else

--- a/sha2/src/sha512_x86.S
+++ b/sha2/src/sha512_x86.S
@@ -23,7 +23,7 @@
 
 
 /* void sha512_compress(uint64_t state[8], const uint8_t block[128]) */
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(_WIN32)
 .globl _sha512_compress
 _sha512_compress:
 #else

--- a/whirlpool/src/x86.S
+++ b/whirlpool/src/x86.S
@@ -24,7 +24,7 @@
 
 /* void whirlpool_compress(uint8_t state[64], const uint8_t block[64]) */
 /* state and block can be optionally aligned to 8 bytes for slightly better performance. */
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(_WIN32)
 .globl _whirlpool_compress
 _whirlpool_compress:
 #else


### PR DESCRIPTION
Fixes #60

I added i686 to the sha1.yml also, it passes on stable, but fails on 1.43.0 probably due to it not being compatible with the version of mingw-w64 and/or gcc provided by msys2.  This also fails on x86_64.  I don't know where it was finding x86_64-w64-mingw32-gcc before, probably something random installed on the runner.  Now it is definitely using the msys2 version.  @mati865